### PR TITLE
🐛 Fix usage of Date.prototype.getYear -> getFullYear

### DIFF
--- a/src/Components/Datepicker.svelte
+++ b/src/Components/Datepicker.svelte
@@ -63,7 +63,7 @@
 
   onMount(() => {
     month = selected.getMonth();
-    year = selected.getYear();
+    year = selected.getFullYear();
   });
 
   function changeMonth(selectedMonth) {


### PR DESCRIPTION
`Date.prototype.getYear` [is deprecated](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getYear) and I think this usage was unintentional. As is, `year` gets a garbage value when `onMount` is called for `DatePicker` and `getYear` [is invoked](https://github.com/6eDesign/svelte-calendar/blob/8bb5fe22cff814dcd1dbef906356ae643ebd4a47/src/Components/Datepicker.svelte#L66), but when the user presses the button to open the calendar `registerOpen` gets called and `year` is [reassigned using the correct API](https://github.com/6eDesign/svelte-calendar/blob/8bb5fe22cff814dcd1dbef906356ae643ebd4a47/src/Components/Datepicker.svelte#L185). I think this is why the bug hasn't been noticed.