### PR TITLE
Improve docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # svelte-calendar
+
 A small date picker built with Svelte.  Demo available here: [svelte-calendar](https://6edesign.github.io/svelte-calendar/)
 
-# Basic usage (svelte v3):
+## Basic usage (svelte v3)
+
 ```html
 <Datepicker
   format="{dateFormat}"
@@ -10,13 +12,15 @@ A small date picker built with Svelte.  Demo available here: [svelte-calendar](h
   selectableCallback={noWeekendsSelectableCallback}
 />
 ```
+
 `start` & `end` are Date objects.
 
 `format` Date formatting uses [timeUtils](https://github.com/6eDesign/timeUtils) formatting.
 
 `selectableCallback` should be a function that accepts a single date as an argument and return true (if selectable) or false (if unavailable).
 
-## Developing/Modifying Svelte-Calendar Guide:
+## Developing/Modifying Svelte-Calendar Guide
+
 *Note that you will need to have [Node.js](https://nodejs.org) installed.*
 
 Install the dependencies...

--- a/README.md
+++ b/README.md
@@ -1,27 +1,49 @@
 # svelte-calendar
 
-A small date picker built with Svelte.  Demo available here: [svelte-calendar](https://6edesign.github.io/svelte-calendar/)
+A small date picker built with Svelte 3. Demo available here: [demo page].
 
-## Basic usage (svelte v3)
+## Basic usage
+
+```html
+<Datepicker />
+```
+
+## With custom settings
 
 ```html
 <Datepicker
-  format="{dateFormat}"
+  format={dateFormat}
   start={threeDaysInPast}
   end={inThirtyDays}
   selectableCallback={noWeekendsSelectableCallback}
 />
 ```
 
-`start` & `end` are Date objects.
+`start` and `end` are [`Date`] objects.
 
-`format` Date formatting uses [timeUtils](https://github.com/6eDesign/timeUtils) formatting.
+`format` Date formatting uses [`timeUtils`] formatting (MM/DD/YYYY by default).
 
-`selectableCallback` should be a function that accepts a single date as an argument and return true (if selectable) or false (if unavailable).
+`selectableCallback` should be a function that accepts a single date as an argument and returns true (if selectable) or false (if unavailable).
+
+More examples can be found on the [demo page].
+
+## Binding data
+
+```html
+<Datepicker
+  bind:selected
+  bind:formattedSelected
+  bind:dateChosen
+/>
+```
+
+`selected` is a [`Date`] object. `formattedSelected` is a string - it's the `Date` object formatted using [`timeUtils`].
+
+`dateChosen` is a boolean, false by default, true after user selection.
 
 ## Developing/Modifying Svelte-Calendar Guide
 
-*Note that you will need to have [Node.js](https://nodejs.org) installed.*
+*Note that you will need to have [Node.js] installed.*
 
 Install the dependencies...
 
@@ -30,10 +52,17 @@ cd svelte-calendar
 npm install
 ```
 
-...then start [Rollup](https://rollupjs.org):
+...then start [Rollup]:
 
 ```bash
 npm run dev
 ```
 
-Navigate to [localhost:5000](http://localhost:5000). You should see your app running. Edit a component file in `src`, save it, and your browser will reload the page so you can see your changes automatically.
+Navigate to [localhost:5000]. You should see your app running. Edit a component file in `src`, save it, and your browser will reload the page so you can see your changes automatically.
+
+[demo page]: https://6edesign.github.io/svelte-calendar/
+[`timeUtils`]: https://github.com/6eDesign/timeUtils
+[`Date`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date
+[Node.js]: https://nodejs.org
+[Rollup]: https://rollupjs.org
+[localhost:5000]: http://localhost:5000


### PR DESCRIPTION
They still could be better, but at least now they will mention all options (so nobody will need to look at the source code `export let`s or "guess" the existence of `selected`).

Some links were repeating so I put them into a separate section. Then I thought it doesn't look right when some URLs are along the texts and others aren't, so I moved them all.