### PR TITLE
Fix lints

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -35,12 +35,10 @@
 	}
 
 	function logChoice(date) {
-	  // eslint-disable-next-line
 	  console.log(`User chose ${date}.`);
 	}
 
 	onMount(() => {
-	  // eslint-disable-next-line
 	  hljs.initHighlightingOnLoad();
 	});
 </script>

--- a/src/Components/Week.svelte
+++ b/src/Components/Week.svelte
@@ -50,6 +50,7 @@
     display: -ms-flexbox;
     display: -webkit-flex;
     display: flex;
+    flex-flow: row;
     -webkit-flex-flow: row;
     justify-content: space-around;
     -ms-grid-column: 1;


### PR DESCRIPTION
I'm not sure which VS Code plugin showed me the CSS lint, but it's fixed now.

I tried removing `eslint-disable-next-line`s. In 2 cases they were unnecessary. In others, I don't agree with `airbnb-base/legacy`. Having to declare a function before using it? What is this, C?