### PR TITLE
Remove unused properties

### DIFF
--- a/src/Components/Week.svelte
+++ b/src/Components/Week.svelte
@@ -7,8 +7,6 @@
 
   export let days;
   export let selected;
-  export let start;
-  export let end;
   export let highlighted;
   export let shouldShakeDate;
   export let direction;


### PR DESCRIPTION
Latest svelte version sleuthed these unused properties out :)

These come up as warnings in your console every build, since 3.15.x, which is also quite annoying.