### PR TITLE
use |local for transitions so that they don't play out on navigation

### DIFF
--- a/src/Components/Week.svelte
+++ b/src/Components/Week.svelte
@@ -14,8 +14,8 @@
 
 <div 
   class="week" 
-  in:fly={{ x: direction * 50, duration: 180, delay: 90 }}
-  out:fade={{ duration: 180 }}
+  in:fly|local={{ x: direction * 50, duration: 180, delay: 90 }}
+  out:fade|local={{ duration: 180 }}
 >
   {#each days as day}
     <div 


### PR DESCRIPTION
Switch to local transitions to prevent navigation from breaking / being delayed when the calendar is present.

Fixes #32 
Fixes #65 