### PR TITLE
if selected is outside range, set it to be the start day

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,5 +8,8 @@
       "language": "svelte",
       "autoFix": true
     }
-  ]
+  ],
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": true
+  }
 }

--- a/src/Components/Datepicker.svelte
+++ b/src/Components/Datepicker.svelte
@@ -44,6 +44,11 @@
     ['December', 'Dec']
   ];
 
+  selected = (
+    selected.getTime() < start.getTime()
+    || selected.getTime() > end.getTime()
+  ) ? start : selected;
+
   export let style = '';
   
   // theming variables:


### PR DESCRIPTION
Fixes https://github.com/6eDesign/svelte-calendar/issues/71