### PR TITLE
Feat: re-add time data to output dates.

### DIFF
--- a/src/Components/Datepicker.svelte
+++ b/src/Components/Datepicker.svelte
@@ -193,6 +193,7 @@
     if (!checkIfVisibleDateIsSelectable(chosen)) return shakeDate(chosen);
     // eslint-disable-next-line
     close();
+    chosen.setHours(selected.getHours(), selected.getMinutes(), 0, 0);
     selected = chosen;
     dateChosen = true;
     assignValueToTrigger(formattedSelected);


### PR DESCRIPTION
Resolves #83.

Simple 1-line fix, assigns the previous states time data to the new state before replacing it, thus ensuring it will remain available.