### PR TITLE
chore: update props in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ prop name            | type                   | default
 `format`             | `string` \| `function` | `'#{m}/#{d}/#{Y}'`
 `daysOfWeek`         | `array`                | En-US Locale (see below)
 `monthsOfYear`       | `array`                | En-US Locale (see below)
+`weekStart`          | `number`               | `0`
 `style`              | `string`               | ""
 
 ### `start` and `end`
@@ -77,6 +78,10 @@ export let monthsOfYear = [
   ['December', 'Dec']
 ];
 ```
+
+### `weekStart`
+
+Determines which day of the week the calendar rows start on. Defaults to `0`, corresponding to Sunday (the 0-index item in default `daysOfWeek`).
 
 ### `style`
 This prop allows you to style the div which wraps the Datepicker component.  This can be useful, for instance, if you'd like to do something like make the component full-width or `display: block;` (by default the element is `inline-block`).  If you would like to style the button that triggers the opening of the datepicker we recommend you pass a custom element (button/link/etc) to the component via its default slot.


### PR DESCRIPTION
When merged, this PR will add the `weekStart` prop and its description to the readme.

I found myself unsure how to change which day the week started on before finding the prop available in `/src`. I believe this small change should prevent this type of mishap for future users.