### PR TITLE
Fix: memory leak in Popover

### DIFF
--- a/src/Components/Popover.svelte
+++ b/src/Components/Popover.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { onMount, createEventDispatcher, tick } from 'svelte';
+  import { onMount, onDestroy, createEventDispatcher, tick } from 'svelte';
 
   const dispatch = createEventDispatcher();
 
@@ -51,6 +51,10 @@
     return () => {
       document.removeEventListener('click', checkForFocusLoss);
     };
+  });
+
+  onDestroy(() => {
+    document.removeEventListener("click", checkForFocusLoss);
   });
 
   const getDistanceToEdges = async () => {


### PR DESCRIPTION
This is a pretty serious memory leak. I use `svelte-calendar` in a web app of mine and this leak drastically slowed the app down over time, had to refresh the page every few actions.