### PR TITLE
feat: add ability to change background (and text) colors

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -136,10 +136,13 @@ var cal = new SvelteCalendar(&#123;
 			buttonBackgroundColor='#e20074'
 			buttonTextColor='white'
 			highlightColor='#e20074'
-			dayBackgroundColor='#efefef'
-			dayTextColor='#333'
-			dayHighlightedBackgroundColor='#e20074'
+			dayBackgroundColor='#374b5e'
+			dayTextColor='#fff'
+			dayBorderColor='#5f75ce'
+			dayHighlightedBackgroundColor='#d93856'
 			dayHighlightedTextColor='#fff'
+			backgroundColor='#2a3048'
+			textColor='#fff'
 		/>
 	</div>
 	<pre><code class="html">
@@ -148,10 +151,13 @@ var cal = new SvelteCalendar(&#123;
   buttonBackgroundColor='#e20074'
   buttonTextColor='white'
   highlightColor='#e20074'
-  dayBackgroundColor='#efefef'
-  dayTextColor='#333'
-  dayHighlightedBackgroundColor='#e20074'
+  dayBackgroundColor='#374b5e'
+  dayTextColor='#fff'
+  dayBorderColor='#5f75ce'
+  dayHighlightedBackgroundColor='#d93856'
   dayHighlightedTextColor='#fff'
+  backgroundColor='#2a3048'
+  textColor='#fff'
 /&gt;
 	</code></pre>
 </div>

--- a/src/Components/Datepicker.svelte
+++ b/src/Components/Datepicker.svelte
@@ -59,8 +59,11 @@
   export let highlightColor = '#f7901e';
   export let dayBackgroundColor = 'none';
   export let dayTextColor = '#4a4a4a';
+  export let dayBorderColor = '#fff';
   export let dayHighlightedBackgroundColor = '#efefef';
   export let dayHighlightedTextColor = '#4a4a4a';
+  export let backgroundColor = '#ffffff';
+  export let textColor = '#3d4548';
 
   internationalize({ daysOfWeek, monthsOfYear });
   let sortedDaysOfWeek = weekStart === 0 ? daysOfWeek : (() => {
@@ -110,8 +113,11 @@
     --highlight-color: ${highlightColor};
     --day-background-color: ${dayBackgroundColor};
     --day-text-color: ${dayTextColor};
+    --day-border-color: ${dayBorderColor};
     --day-highlighted-background-color: ${dayHighlightedBackgroundColor};
     --day-highlighted-text-color: ${dayHighlightedTextColor};
+    --background-color: ${backgroundColor};
+    --text-color: ${textColor};
     ${style}
   `;
 
@@ -348,6 +354,8 @@
     width: 100vw;
     padding: 10px;
     padding-top: 0;
+    background-color: var(--background-color);
+    color: var(--text-color);
   }
 
   @media (min-width: 480px) {
@@ -359,7 +367,7 @@
   }
 
   .legend {
-    color: #4a4a4a;
+    color: var(--text-color);
     padding: 10px 0;
     margin-bottom: 5px;
   }

--- a/src/Components/NavBar.svelte
+++ b/src/Components/NavBar.svelte
@@ -80,7 +80,6 @@
     padding: 24px 15px;
     display: flex;
     justify-content: space-between;
-    color: #3d4548;
     font-weight: bold;
   }
   .label { 
@@ -110,7 +109,6 @@
     margin: .5%; 
     height: 23%;
     display: inline-block;
-    color: #4a4a4a;
     border: 1px solid #efefef;
     opacity: 0.2;
   }

--- a/src/Components/Week.svelte
+++ b/src/Components/Week.svelte
@@ -105,7 +105,7 @@
     flex-direction: column;
     width: 100%;
     position: relative;
-    border: 1px solid #fff;
+    border: 1px solid var(--day-border-color);
     border-radius: 50%; 
     margin: 10%;
     padding: 0;


### PR DESCRIPTION
Implements #76.

Had to also give the ability to change the text color of year and day names, as well as
the border color around names (otherwise it would end up looking not great).

The example site has also been changed to reflect this new ability. Pardon my perhaps
poor chose of colors for the example. Feel free to change them to something that looks
better.