### PR TITLE
Fixed faulty date after navigation...

### DIFF
--- a/src/lib/stores/datepicker.js
+++ b/src/lib/stores/datepicker.js
@@ -59,8 +59,15 @@ const get = ({ selected, start, end, startOfWeekIndex = 0, shouldEnlargeDay = fa
 			return clampable.reduce((day, type) => day[type](boundary[type]()), day);
 		},
 		add(amount, unit, clampable = []) {
+         const { start, end } = this.getState();
 			update(({ month, year, day, ...state }) => {
-				const d = this.clampValue(dayjs(new Date(year, month, day)).add(amount, unit), clampable);
+				let d = this.clampValue(dayjs(new Date(year, month, day)).add(amount, unit), clampable);
+            if (d.isBefore(start)) {
+               d = dayjs(start);
+            }
+            else if (d.isAfter(end)) {
+               d = dayjs(end);
+            }
 				if (!this.isSelectable(d.toDate())) return { ...state, year, month, day };
 				return {
 					...state,


### PR DESCRIPTION
…and impossible to navigate to valid month using arrow buttons if we end up outside start-end interval. https://github.com/6eDesign/svelte-calendar/issues/152